### PR TITLE
Remove compiler warnings when compiling on Mavericks. 

### DIFF
--- a/src/utils.m
+++ b/src/utils.m
@@ -107,7 +107,7 @@ x_get_string_property (Window xwindow_id, Atom atom)
         if (type == atoms.utf8_string)
             ret = [NSString stringWithUTF8String:(char *) data];
         else
-            ret = [NSString stringWithCString:(char *) data];
+            ret = [NSString stringWithCString:(char *) data encoding:NSASCIIStringEncoding];
     }
 
     XFree (data);

--- a/src/x-window.m
+++ b/src/x-window.m
@@ -2652,7 +2652,7 @@ decode_size_hints (XSizeHints *hints, int base[2], int min[2],
     if (_title != nil)
         return [NSString stringWithFormat:@"{x-window %@}", _title];
     else
-        return [NSString stringWithFormat:@"{x-window 0x%x}", _id];
+        return [NSString stringWithFormat:@"{x-window 0x%lx}", _id];
 }
 
 - (X11Rect) intended_frame


### PR DESCRIPTION
Using clang on Darwin 13.0.1:

```
──── make
  OBJC     dock-support-handler.o
  OBJC     frame.o
  OBJC     main.o
  OBJC     utils.o
utils.m:110:29: warning: 'stringWithCString:' is deprecated: first
      deprecated in OS X 10.4 [-Wdeprecated-declarations]
            ret = [NSString stringWithCString:(char *) data];
                            ^
/System/Library/Frameworks/Foundation.framework/Headers/NSString.h:363:1: note: 
      method 'stringWithCString:' declared here
+ (id)stringWithCString:(const char *)bytes NS_DEPRECATED(10_0, 10...
^
1 warning generated.
  OBJC     x-input.o
  CC       x-list.o
  OBJC     x-screen.o
  OBJC     x-window.o
x-window.m:2655:63: warning: format specifies type 'unsigned int' but the
      argument has type 'Window' (aka 'unsigned long') [-Wformat]
        return [NSString stringWithFormat:@"{x-window 0x%x}", _id];
                                                        ~~    ^~~
                                                        %lx
1 warning generated.
  CC       x11-geometry.o
  OBJCLD   quartz-wm

```
