### PR TITLE
Print actual prefs domain in --help.

### DIFF
--- a/src/main.m
+++ b/src/main.m
@@ -967,7 +967,7 @@ int main (int argc, const char *argv[]) {
                    "Aqua window manager for X11.\n\n"
                    "--version                 Print the version string\n"
                    "--prefs-domain <domain>   Change the domain used for reading preferences\n"
-                   "                          (default: "BUNDLE_ID_PREFIX".X11)\n");
+                   "                          (default: %s)\n", app_prefs_domain);
             return 0;
         } else {
             fprintf(stderr, "usage: quartz-wm OPTIONS...\n"


### PR DESCRIPTION
If the prefs domain is being overridden using the X11_PREFS_DOMAIN enviroment variable, print the overridden value in the --help message.

(This would have saved me some initial confusion. But one could argue that people - e.g., me - should read the documentation more closely.)

--Tom
