### PR TITLE
Show key equivalent in window title.

### DIFF
--- a/man/quartz-wm.man
+++ b/man/quartz-wm.man
@@ -84,6 +84,8 @@ Automatically quit
 Set the timeout for the auto-quit feature.  If wm_auto_quit is true, quartz-wm
 will wait this many seconds before attempting to shutdown.  If another window
 is created in that time, quartz-wm will not shutdown.
+.It defaults write __bundle_id_prefix__.X11 wm_show_shortcut -bool true
+Show each window's key equivalent, if it has one, in its title bar.
 .El
 .Sh LOGGING
 .Pp

--- a/src/frame.h
+++ b/src/frame.h
@@ -69,7 +69,8 @@ typedef enum xp_frame_attr_enum xp_frame_attr;
 
 extern void draw_frame (int screen, Window xwindow_id, X11Rect outer_r,
                         X11Rect inner_r, xp_frame_class class,
-                        xp_frame_attr attr, CFStringRef title);
+                        xp_frame_attr attr, CFStringRef title,
+                        int shortcut_index);
 extern int frame_titlebar_height (xp_frame_class class);
 extern X11Rect frame_tracking_rect (X11Rect outer_r, X11Rect inner_r,
                                     xp_frame_class class);

--- a/src/main.m
+++ b/src/main.m
@@ -69,6 +69,11 @@ BOOL rootless = YES;
 BOOL auto_quit = NO;
 int auto_quit_timeout = 3;   /* Seconds to wait before auto-quiting */
 BOOL minimize_on_double_click = YES;
+BOOL show_shortcut = NO;
+BOOL enable_key_equivalents = YES; /* quartz-wm doesn't use this per
+                                    * se, but it queries it so it knows
+                                    * not to display shortcuts when key
+                                    * equivalents are disabled. */
 
 aslclient aslc;
 
@@ -876,6 +881,8 @@ static inline void prefs_read(void) {
     auto_quit           = prefs_get_bool (CFSTR (PREFS_AUTO_QUIT), auto_quit);
     auto_quit_timeout   = prefs_get_int (CFSTR (PREFS_AUTO_QUIT_TIMEOUT), auto_quit_timeout);
     minimize_on_double_click = prefs_get_bool (CFSTR(PREFS_MINIMIZE_ON_DOUBLE_CLICK), minimize_on_double_click);
+    show_shortcut       = prefs_get_bool (CFSTR (PREFS_SHOW_SHORTCUT), show_shortcut);
+    enable_key_equivalents = prefs_get_bool (CFSTR (PREFS_ENABLE_KEY_EQUIVALENTS), enable_key_equivalents);
 }
 
 static void signal_handler_cb(CFRunLoopObserverRef observer,
@@ -902,6 +909,8 @@ static void signal_handler_cb(CFRunLoopObserverRef observer,
                         [w do_unshade:CurrentTime];
                     [w update_net_wm_action_property];
                 }
+
+                [w decorate];
             }
         }
     }

--- a/src/quartz-wm.h
+++ b/src/quartz-wm.h
@@ -77,10 +77,12 @@
 #define PREFS_AUTO_QUIT "wm_auto_quit"
 #define PREFS_AUTO_QUIT_TIMEOUT "wm_auto_quit_timeout"
 #define PREFS_MINIMIZE_ON_DOUBLE_CLICK "AppleMiniaturizeOnDoubleClick"
+#define PREFS_SHOW_SHORTCUT "wm_show_shortcut"
+#define PREFS_ENABLE_KEY_EQUIVALENTS "enable_key_equivalents"
 
 /* from main.m */
 extern x_list *screen_list;
-extern BOOL focus_follows_mouse, focus_click_through, limit_window_size, focus_on_new_window, window_shading, rootless, auto_quit, minimize_on_double_click;
+extern BOOL focus_follows_mouse, focus_click_through, limit_window_size, focus_on_new_window, window_shading, rootless, auto_quit, minimize_on_double_click, show_shortcut, enable_key_equivalents;
 extern int auto_quit_timeout;
 extern void x_grab_server (Bool do_sync);
 extern void x_ungrab_server (void);

--- a/src/x-window.m
+++ b/src/x-window.m
@@ -1043,7 +1043,7 @@ ENABLE_EVENTS (_id, X_CLIENT_WINDOW_EVENTS)
     _drawn_frame_decor = [self get_xp_frame_class] & XP_FRAME_CLASS_DECOR_MASK;
     
     draw_frame (_screen->_id, _frame_id, or, ir, [self get_xp_frame_class],
-                frame_attr, (CFStringRef) [self title]);
+                frame_attr, (CFStringRef) [self title], _shortcut_index);
 
     _decorated = YES;
     _pending_decorate = NO;


### PR DESCRIPTION
Show key equivalent in window title, so the shortcut is obvious at a glance.

By default, this is disabled. To enable it, set the new wm_show_shortcut default to true.

--Tom

![key_equivalents](https://cloud.githubusercontent.com/assets/1269020/5081236/69df5c64-6ec4-11e4-8070-6757126c8f75.jpg)
